### PR TITLE
Added to readme: require gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ ok
 
 ### Require
 
+gcc
+
 cmake version >= 3.10
 
 如果你的cmake版本低,请去修改*CMakeLists.txt*文件第一行的需求版本.


### PR DESCRIPTION
在 Mac 用 clang 编译本项目（指的是：按本文档指示编译，但 `gcc` 命令实际指向 `/usr/bin/clang` ），是会报 `'bits/types/FILE.h' file not found` 的。这个库是 GCC 的。


